### PR TITLE
Added arithmetic completion from compe

### DIFF
--- a/lua/cmp_calc/init.lua
+++ b/lua/cmp_calc/init.lua
@@ -43,8 +43,8 @@ source.complete = function(self, request, callback)
   callback({
     items = {
       {
-        word = input .. ' = ' .. value,
-        label = program .. ' = ' .. value,
+        word = input,
+        label = program,
         filterText = input .. string.rep(table.concat(self:get_trigger_characters(), ''), 2), -- keep completion menu after operator or whitespace.
         textEdit = {
           range = {
@@ -60,6 +60,24 @@ source.complete = function(self, request, callback)
           newText = value,
         },
       },
+      {
+        word = input .. ' = ' .. value,
+        label = program .. ' = ' .. value,
+        filterText = input .. string.rep(table.concat(self:get_trigger_characters(), ''), 2), -- keep completion menu after operator or whitespace.
+        textEdit = {
+          range = {
+            start = {
+              line = request.context.cursor.row - 1,
+              character = delta + request.offset - 1,
+            },
+            ['end'] = {
+              line = request.context.cursor.row - 1,
+              character = request.context.cursor.col - 1,
+            },
+          },
+          newText = input .. ' = ' .. value,
+        },
+      }
     },
     isIncomplete = true,
   })


### PR DESCRIPTION
### Explanation
Basically, **nvim-compe** has two Calc completion items: the result itself, like `5 + 5` results in `10`; and the "input + result" (arithmetic), like `5 + 5` results in `5 + 5 = 10`. So, this PR adds the last one.

### Screenshots/Video

https://user-images.githubusercontent.com/59768785/136708813-83db10cd-2768-4c0b-b661-1f0d086688a7.mov

