### PR TITLE
Display the result itself in the completion menu

### DIFF
--- a/lua/cmp_calc/init.lua
+++ b/lua/cmp_calc/init.lua
@@ -43,8 +43,8 @@ source.complete = function(self, request, callback)
   callback({
     items = {
       {
-        word = input,
-        label = program,
+        word = value,
+        label = value,
         filterText = input .. string.rep(table.concat(self:get_trigger_characters(), ''), 2), -- keep completion menu after operator or whitespace.
         textEdit = {
           range = {


### PR DESCRIPTION
It seems more logical to display the result itself in the completion menu. It also prevents misunderstandings like #2 and maintains a certain consistency across both completion options.