### PR TITLE
fix completion starting with paren + perf optimize

### DIFF
--- a/lua/cmp_calc/init.lua
+++ b/lua/cmp_calc/init.lua
@@ -121,7 +121,7 @@ source._trim_right = function(_, text)
   return string.gsub(text, '%s*$', '')
 end
 
-source.trigger_chars = {',','0','1','2','3','4','5','6','7','8','9',')'}
+source.trigger_chars = {',', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ')', ' '}
 
 -- Keyword matching pattern (vim regex)
 source._keyptn = [[\s*\zs\(\d\+\(\.\d\+\)\?\|[,+/*%^()-]\|\s\|]] ..

--- a/lua/cmp_calc/init.lua
+++ b/lua/cmp_calc/init.lua
@@ -14,15 +14,11 @@ source.get_position_encoding_kind = function()
 end
 
 source.get_trigger_characters = function()
-  local chars = ',0123456789)'
-  for _, key in ipairs(math_keys) do
-    chars = chars .. key
-  end
-  return vim.fn.split(chars, [[\zs]])
+  return source.trigger_chars
 end
 
-source.get_keyword_pattern = function(self)
-  return self._keyptn
+source.get_keyword_pattern = function()
+  return source._keyptn
 end
 
 source.complete = function(self, request, callback)
@@ -124,6 +120,8 @@ end
 source._trim_right = function(_, text)
   return string.gsub(text, '%s*$', '')
 end
+
+source.trigger_chars = {',','0','1','2','3','4','5','6','7','8','9',')'}
 
 -- Keyword matching pattern (vim regex)
 source._keyptn = [[\s*\zs\(\d\+\(\.\d\+\)\?\|[,+/*%^()-]\|\s\|]] ..

--- a/lua/cmp_calc/init.lua
+++ b/lua/cmp_calc/init.lua
@@ -22,7 +22,7 @@ source.get_keyword_pattern = function()
 end
 
 source.complete = function(self, request, callback)
-  local input = self:_trim_right(string.sub(request.context.cursor_before_line, request.offset))
+  local input = string.sub(request.context.cursor_before_line, request.offset)
 
   -- Resolve math_keys
   for _, key in ipairs(math_keys) do
@@ -36,7 +36,7 @@ source.complete = function(self, request, callback)
   end
 
   -- Ignore if input has no math operators.
-  if string.match(program, '^[%s%d%.]*$') ~= nil then
+  if string.match(program, '^[ %d().]*$') ~= nil then
     return callback({ isIncomplete = true })
   end
 
@@ -121,14 +121,10 @@ source._analyze = function(_, input)
   return input, 0
 end
 
-source._trim_right = function(_, text)
-  return string.gsub(text, '%s*$', '')
-end
-
-source._trigger_chars = { ',', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ')' }
+source._trigger_chars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ')' }
 
 -- Keyword matching pattern (vim regex)
-source._keyptn = [[\s*\zs\(\d\+\(\.\d\+\)\?\|[,+/*%^()-]\|\s\|]] ..
-  table.concat(math_keys, '\\|') .. '\\)\\+'
+source._keyptn = [[\s*\zs\(\d\+\(\.\d\+\)\?\|[ ()^*/%+-]\|]] ..
+  table.concat(math_keys, '\\|') .. [[\)\+]]
 
 return source


### PR DESCRIPTION
In the current form, expressions starting with `(` are recognized as with unmatched parens, this can be fixed by simplifying the unmatched paren detector.

Also the pattern used to detect a keyword is static, so there is no reason to concatenate the string on every test. Neither do we need to escape the math functions - identifiers can't contains any regex-specific chars.