### PR TITLE
Avoid false suggestions and improve practicality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ nvim-cmp source for math calculation.
 
 # Setup
 
+1. Add the plugin to `nvim-cmp` dependency list.
+2. Add it as a source:
+
 ```lua
 require'cmp'.setup {
   sources = {
@@ -12,3 +15,11 @@ require'cmp'.setup {
 }
 ```
 
+3. Type a math expression anywhere or use a method as defined in lua `math` table.
+
+```lua
+-- compute and replace ('|' means the cursor position)
+your(code, 2.5*log10(100)|) -> your(code, 5|)
+-- or append just the result
+sqrt(2)^2| -> sqrt(2)^2 = 2|
+```

--- a/lua/cmp_calc/init.lua
+++ b/lua/cmp_calc/init.lua
@@ -24,11 +24,6 @@ end
 source.complete = function(self, request, callback)
   local input = string.sub(request.context.cursor_before_line, request.offset)
 
-  -- Resolve math_keys
-  for _, key in ipairs(math_keys) do
-    input = string.gsub(input, vim.pesc(key), 'math.' .. key)
-  end
-
   -- Analyze column count.
   local delta = self:_analyze(input)
   if not delta then
@@ -45,7 +40,7 @@ source.complete = function(self, request, callback)
   end
 
   -- Ignore if failed to interpret to Lua.
-  local m = load('return ' .. program)
+  local m = load('return ' .. program, 'cmp-calc', 't', math)
   if type(m) ~= 'function' then
     return callback({ isIncomplete = true })
   end

--- a/lua/cmp_calc/init.lua
+++ b/lua/cmp_calc/init.lua
@@ -138,7 +138,7 @@ end
 source._trigger_chars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ')' }
 
 -- Keyword matching pattern (vim regex)
-source._keyptn = [[\s*\zs\(\d\+\(\.\d\+\)\?\|[ ()^*/%+-]\|]] ..
-  table.concat(math_keys, '\\|') .. [[\)\+]]
+source._keyptn = [[\s*\zs\(\d\+\(\.\d\+\)\?\|[ ()^*/%+-]\|\<]] ..
+  table.concat(math_keys, '\\|\\<') .. [[\)\+]]
 
 return source

--- a/lua/cmp_calc/init.lua
+++ b/lua/cmp_calc/init.lua
@@ -138,7 +138,11 @@ end
 source._trigger_chars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ')' }
 
 -- Keyword matching pattern (vim regex)
-source._keyptn = [[\s*\zs\(\d\+\(\.\d\+\)\?\|[ ()^*/%+-]\|\<]] ..
-  table.concat(math_keys, '\\|\\<') .. [[\)\+]]
+source._keyptn = ([[\s*\zs\(%s\)\+]]):format(table.concat({
+  -- int  (float)?    (sci e± int)?
+  [[\d\+\(\.\d\+\)\?\(e[+-]\?\d\+\)\?]],
+  '[ ()^*/%+-]', -- operators
+  '\\<' .. table.concat(math_keys, '\\|\\<'),
+}, '\\|'))
 
 return source


### PR DESCRIPTION
- avoids making suggestions for partially-matching words (`api` would otherwise result in suggestion `amath.pi`, now doesn't suggest unless the match is also the start of the word)
- included science _e_ from #12
- included removed `math.` method prefix from #13
- improved README information to resolve #9 and #8 